### PR TITLE
Fixed bug that causes every preprint to have the same vector

### DIFF
--- a/server/word_vectors.py
+++ b/server/word_vectors.py
@@ -2,7 +2,7 @@ import numpy as np
 import pickle
 from io import BytesIO, StringIO
 from gensim.parsing.preprocessing import remove_stopwords
-from pdfminer.high_level import eextract_text_to_fp
+from pdfminer.high_level import extract_text_to_fp
 from pdfminer.layout import LAParams
 
 word_model_wv = pickle.load(open('data/word2vec_model/word_model.wv.pkl', 'rb'))


### PR DESCRIPTION
Closes #38.

This PR fixes the bug appearing in #38. If LAParams is not passed in the returned string doesn't contain any newline characters. This means every article passed in will have the same nonsense vector. Hence two totally different papers have  will appear the same. 
