### PR TITLE
Create virtualenv in home directory (instead of in server subdir)

### DIFF
--- a/server/deployment/setup.sh
+++ b/server/deployment/setup.sh
@@ -18,8 +18,8 @@ mkdir data
 aws s3 cp --recursive s3://preprint-similarity-search/data_for_deployment ./data
 
 # (3) Set up virtualenv
-virtualenv -p python3 venv
-source venv/bin/activate
+python3 -m venv ~/venv
+source ~/venv/bin/activate
 pip install -r requirements.txt
 
 # =============================================================================

--- a/server/deployment/supervisor.conf
+++ b/server/deployment/supervisor.conf
@@ -1,6 +1,6 @@
 [program:gunicorn-app]
 directory=/home/ubuntu/preprint-similarity-search/server
-command=/home/ubuntu/preprint-similarity-search/server/venv/bin/gunicorn app_runner:app --bind='127.0.0.1:8001' --timeout=300
+command=/home/ubuntu/venv/bin/gunicorn app_runner:app --bind='127.0.0.1:8001' --timeout=300
 autostart=true
 autorestart=true
 stdout_logfile=/var/log/supervisor/preprint-similarity-search.log

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -9,5 +9,6 @@ pdfminer.six==20200517
 requests==2.23.0
 scikit-learn==0.22.1
 sentry-sdk[flask]==0.17.0
+setuptools>=41.0.0
 tables==3.6.1
 tensorflow==1.15.4


### PR DESCRIPTION
This is a quick fix that changes the location of virtualenv from the repo's `server` subdirectory to user's home directory. It will prevent the repo's name from interfering with deployment.  I have tested it on local environment.

`setuptools` is added in `requirements.txt` to avoid an annoying compatibility warning message generated by  `pip install` command.