### PR TITLE
Changes based on Google Cloud Platform deployment

### DIFF
--- a/frontend/src/backend.js
+++ b/frontend/src/backend.js
@@ -1,6 +1,6 @@
 import { CustomError } from './error';
 
-const backendServer = 'https://api-preprint-similarity-search.greenelab.com/doi/';
+const backendServer = 'https://api-pss.greenelab.com/doi/';
 
 // get neighbor and coordinate data from backend
 export const getNeighbors = async (query) => {

--- a/server/deployment/nginx.conf
+++ b/server/deployment/nginx.conf
@@ -10,13 +10,13 @@ server {
     listen 443;
     server_name _;
 
-    if ( $http_host !~* ^(api-preprint-similarity-search\.greenelab\.com)$ ) {
+    if ( $http_host !~* ^(api-pss\.greenelab\.com)$ ) {
         return 444;
     }
 
     ssl on;
-    ssl_certificate     /etc/letsencrypt/live/api-preprint-similarity-search.greenelab.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/api-preprint-similarity-search.greenelab.com/privkey.pem;
+    ssl_certificate     /etc/letsencrypt/live/api-pss.greenelab.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/api-pss.greenelab.com/privkey.pem;
 
     location / {
         proxy_pass http://127.0.0.1:8001;

--- a/server/deployment/setup.sh
+++ b/server/deployment/setup.sh
@@ -13,6 +13,15 @@ git clone https://github.com/greenelab/preprint-similarity-search.git
 cd preprint-similarity-search/server
 git submodule update --init
 
+# If the PR `https://github.com/KrishnaswamyLab/SAUCIE/pull/38` hasn't
+# been merged, please change the following line in `SAUCIE/utils.py`:
+#     import tensorflow as tf
+# into:
+#     import tensorflow as tf
+#     if not tf.__version__.startswith("1."):
+#         import tensorflow.compat.v1 as tf
+#         tf.disable_eager_execution()
+
 # (2) Copy data files from AWS S3 to local `server/data/` directory
 mkdir data
 aws s3 cp --recursive s3://preprint-similarity-search/data_for_deployment ./data
@@ -31,9 +40,9 @@ sudo apt update
 
 # (1) Install `certbot` to manage SSL certificates,
 EMAIL="team@greenelab.com"
-DOMAIN_NAME="api-preprint-similarity-search.greenelab.com"
+DOMAIN_NAME="api-pss.greenelab.com"
 
-sudo apt install certbot python-certbot-nginx -y
+sudo apt install certbot python3-certbot-nginx -y
 sudo certbot certonly --nginx --noninteractive --no-eff-email --agree-tos \
      --email $EMAIL --domains ${DOMAIN_NAME}
 

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -11,4 +11,4 @@ scikit-learn==0.22.1
 sentry-sdk[flask]==0.17.0
 setuptools>=41.0.0
 tables==3.6.1
-tensorflow==1.15.4
+tensorflow==2.3.1


### PR DESCRIPTION
This PR includes a few updates that I made when deploying it on Ubuntu 20.04 hosted by Google Cloud Platform(GCP). 

I also tried to fix this issue: 
https://github.com/greenelab/preprint-similarity-search/network/alert/server/requirements.txt/tensorflow/open
but `pip install tensorflow>=2.4.0` command got some timeout error, which could be because version 2.4.x is only a prerelease (as of 12/10/2020): https://pypi.org/project/tensorflow/#history

So this issue will have to be handled later.