### PR TITLE
Remove wonky papers

### DIFF
--- a/server/auto_updater/dataset_updater.py
+++ b/server/auto_updater/dataset_updater.py
@@ -239,6 +239,10 @@ def generate_vector_counts(model, document_path, xpath, filter_tags=filter_tag_l
         )
     )
 
+    # Skip wonky papers that have less than 20 tokens
+    if len(all_tokens) < 20:
+        return [], None
+
     word_vectors += [model.wv[text] for text in all_tokens]
 
     # skips weird documents that don't contain text


### PR DESCRIPTION
@danich1 and @cgreene Is it necessary to remove all these wonky papers from the current paper collection (`global_doc_word_counter.tsv` and `paper_dataset_full.tsv`) and rebuild the centroid and `pmc_square_plot.json` files? Since I have already collected all tokens from the papers up to 04/26/2021 and the pipeline works, it's easy to do (just need a few hours of computation time).