### PR TITLE
Tweak knn searching

### DIFF
--- a/server/find_knn.py
+++ b/server/find_knn.py
@@ -52,11 +52,11 @@ def get_neighbors(user_doi):
 def get_journal_knn(query_vec):
     """Find the K nearest journals."""
 
-    A_journal = journal_model.kneighbors_graph(query_vec, mode="distance")
-    matched_rows = list(A_journal.indices)
+    top_journals = journal_model.kneighbors_graph(query_vec, mode="distance")
+    matched_rows = list(top_journals.indices)
     journal_data = list(
         zip(
-            A_journal.data,
+            top_journals.data,
             journal_df.reset_index().document[matched_rows].tolist(),
         )
     )
@@ -75,12 +75,11 @@ def get_journal_knn(query_vec):
 def get_paper_knn(query_vec):
     """Find the K nearest papers."""
 
+    top_papers = paper_model.kneighbors_graph(query_vec, mode="distance")
+    matched_rows = list(top_papers.indices)
+    distances = list(top_papers.data)
+
     paper_knn = list()
-    papers = paper_model.kneighbors_graph(query_vec, mode="distance")
-
-    matched_rows = list(papers.indices)
-    distances = list(papers.data)
-
     for idx, row in enumerate(matched_rows):
         node = {
             "distance": distances[idx],

--- a/server/find_knn.py
+++ b/server/find_knn.py
@@ -53,11 +53,11 @@ def get_journal_knn(query_vec):
     """Find the K nearest journals."""
 
     A_journal = journal_model.kneighbors_graph(query_vec, mode="distance")
-    cols = A_journal.nonzero()[1]
+    matched_rows = list(A_journal.indices)
     journal_data = list(
         zip(
             A_journal.data,
-            journal_df.reset_index().document[cols].tolist(),
+            journal_df.reset_index().document[matched_rows].tolist(),
         )
     )
 
@@ -77,12 +77,11 @@ def get_paper_knn(query_vec):
 
     paper_knn = list()
     papers = paper_model.kneighbors_graph(query_vec, mode="distance")
-    cols = papers.nonzero()[1]
 
-    dataset_rows = list(cols)
+    matched_rows = list(papers.indices)
     distances = list(papers.data)
 
-    for idx, row in enumerate(dataset_rows):
+    for idx, row in enumerate(matched_rows):
         node = {
             "distance": distances[idx],
             "pmcid": pmc_map[row],


### PR DESCRIPTION
@danich1 I feel that calling `nonzero()` method on the matched journals/papers is neither necessary nor correct, because the document specified by user's input DOI doesn't overlap with any papers in our collection. 

Given that an input DOI's content matches exactly with any papers in our collection, they shouldn't be skipped at all. (I know that it's very unlikely, considering that the feature vectors are floating point values.)

Perfectly matched journals (again, very unlikely) definitely shouldn't be skipped. Instead, they are gems that should be put at the top of our search result.