### PR TITLE
Implement plain text search, tooltips, and other frontend touch ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # Preprint Similarity Search
 
-[⭐ OPEN THE APP ⭐](https://greenelab.github.io/preprint-similarity-search/)
+[⭐ OPEN THE APP](https://greenelab.github.io/preprint-similarity-search/) to start using the tool right away
 
-**Also available as an API:
-`https://api-preprint-similarity-search.greenelab.com/doi/[YOUR DOI HERE]`**
+[📜 READ THE MANUSCRIPT](http://greenelab.github.io/annorxiver_manuscript) for technical details on the machine learning model behind the tool
 
-### About this tool
+[🤖 USE THE API](https://api-pss.greenelab.com/doi/10.1101/833400) like `https://api-pss.greenelab.com/doi/YOUR-DOI`
+
+Based on the work and classifiers in the [AnnoRxiver project](http://github.com/greenelab/annorxiver/)
+
+### About
 
 This tool uses a machine learning model trained on 2.3 million [PubMed Central open access documents](https://www.ncbi.nlm.nih.gov/pmc/tools/openftlist/) 
 to find similar papers and journals based on the textual content of your [bioRxiv](https://www.biorxiv.org/) or [medRxiv](https://www.medrxiv.org/) preprint.
@@ -14,17 +17,7 @@ These results can be used as a starting point when searching for a place to publ
 The tool also provides a "map" of the PubMed Central documents, grouped into bins based on similar textual content, and shows you where your preprint 
 falls on the map. Select a square to learn more about the papers in that bin.
 
-The map also incorporates a set of 50 [principal components](https://en.wikipedia.org/wiki/Principal_component_analysis) (PCs) generated from bioRxiv.
+The map also incorporates a set of 50 [principal components](https://en.wikipedia.org/wiki/Principal_component_analysis) (PCs) generated from bio/medRxiv.
 Each PC represents two high level concepts characterized by keywords of various strengths, illustrated in the word cloud thumbnails above the map.
 Select a thumbnail to color the map by that PC.
 Deeper orange squares will be papers that correlate more with the orange keywords in the image, and vice versa for blue.
-
-### How does it work?
-
-This tool is based on work done in the [AnnoRxiver project](http://github.com/greenelab/annorxiver/).
-
-It utilizes two k-nearest neighbor classifiers to recommend journals.
-The first classifier is based on individual paper proximities, while the second classifier is based on close proximity to a journal's centroid.
-More information on the training and tuning of these classifiers -- and other technical information related to this tool -- can be found in our 
-[manuscript](http://greenelab.github.io/annorxiver_manuscript). 
-Code for the classifiers can be found [here](http://github.com/greenelab/annorxiver/).

--- a/frontend/src/about.js
+++ b/frontend/src/about.js
@@ -1,11 +1,15 @@
+import Tooltip from "./tooltip";
+
 // about section
 
 const About = () => (
   <section id="help">
-    <h3>
-      <i className="fas fa-question-circle"></i>
-      <span>About this tool</span>
-    </h3>
+    <Tooltip content="Overview of this tool in more detail">
+      <h3>
+        <i className="fas fa-question-circle"></i>
+        <span>About this tool</span>
+      </h3>
+    </Tooltip>
     <p>
       This tool uses a machine learning model trained on 1.7 million{" "}
       <a href="https://www.ncbi.nlm.nih.gov/pmc/tools/openftlist/">
@@ -28,16 +32,16 @@ const About = () => (
       <a href="https://en.wikipedia.org/wiki/Principal_component_analysis">
         principal components
       </a>{" "}
-      (PCs) generated from bioRxiv. Each PC represents two high level concepts
-      characterized by keywords of various strengths, illustrated in the word
-      cloud thumbnails above the map. Select a thumbnail to color the map by
-      that PC. Deeper orange squares will be papers that correlate more with the
-      orange keywords in the image, and vice versa for blue.
+      (PCs) generated from bio/medRxiv. Each PC represents two high level
+      concepts characterized by keywords of various strengths, illustrated in
+      the word cloud thumbnails above the map. Select a thumbnail to color the
+      map by that PC. Deeper orange squares will be papers that correlate more
+      with the orange keywords in the image, and vice versa for blue.
     </p>
     <p>
       For more information, see the{" "}
       <a href="https://github.com/greenelab/preprint-similarity-search">
-        readme on GitHub
+        links in the readme
       </a>
       .
     </p>

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -151,13 +151,3 @@ img {
 *:focus {
   outline: solid 2px var(--black);
 }
-
-/* tooltip */
-.tooltip {
-  max-width: min(300px, 100%);
-  padding: 10px 15px;
-  border-radius: 5px;
-  background: var(--black);
-  color: var(--white);
-  font-size: 0.8rem;
-}

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -42,7 +42,6 @@ const App = () => {
           }}
         />
         <Status {...{ status }} />
-        <hr />
         {status === success && (
           <>
             <PreprintInfo {...{ preprint }} />
@@ -50,9 +49,9 @@ const App = () => {
             <SimilarPapers {...{ similarPapers }} />
             <hr />
             <SimilarJournals {...{ similarJournals }} />
-            <hr />
           </>
         )}
+        <hr />
         <MapSections {...{ coordinates }} />
         <hr />
         <About />

--- a/frontend/src/backend.js
+++ b/frontend/src/backend.js
@@ -12,8 +12,6 @@ export const getNeighbors = async ({ doi, text }) => {
   if (!response.ok) throw new Error();
   const neighbors = await response.json();
 
-  console.log(neighbors);
-
   // if error returned, throw error with message
   if (neighbors.message) throw new CustomError(neighbors.message);
 

--- a/frontend/src/backend.js
+++ b/frontend/src/backend.js
@@ -1,13 +1,18 @@
 import { CustomError } from "./error";
 
-const backendServer = "https://api-pss.greenelab.com/doi/";
+const doiServer = "https://api-pss.greenelab.com/doi";
+const textServer = "https://api-pss.greenelab.com/text";
 
 // get neighbor and coordinate data from backend
-export const getNeighbors = async (query) => {
+export const getNeighbors = async ({ doi, text }) => {
   // look up data from backend
-  const response = await fetch(backendServer + query);
+  const url = text ? textServer : doiServer + "/" + doi;
+  const options = { method: text ? "POST" : "GET", body: text || null };
+  const response = await fetch(url, options);
   if (!response.ok) throw new Error();
   const neighbors = await response.json();
+
+  console.log(neighbors);
 
   // if error returned, throw error with message
   if (neighbors.message) throw new CustomError(neighbors.message);
@@ -50,19 +55,21 @@ export const getNeighborsMetadata = async (array) => {
 };
 
 // clean preprint data to handle more conveniently
-export const cleanPreprint = (preprint) => ({
+export const cleanPreprint = (preprint = {}) => ({
   // doi
   id: preprint.doi || null,
   // name of paper
   title: preprint.title || "",
   // authors of paper
-  authors: (preprint.authors || []).split("; ").join(", "),
+  authors: (preprint.authors || "").split("; ").join(", "),
   // name of journal
   journal: preprint.publisher || "",
   // year of publication
-  year: preprint.accepted_date.split("-")[0] || "",
+  year: (preprint.accepted_date || "").split("-")[0] || "",
   // is preliminary (PDF) result or XML/HTML result
   prelim: preprint.xml_found ? false : true,
+  // is a direct plain text upload
+  text: preprint.title ? false : true
 });
 
 // clean journal or paper neighbor data to handle more conveniently

--- a/frontend/src/card.css
+++ b/frontend/src/card.css
@@ -16,7 +16,6 @@
   margin-right: 20px;
   border-radius: 999px;
   font-weight: 700;
-  cursor: help;
 }
 .card_details {
   flex-grow: 1;

--- a/frontend/src/cell-details.js
+++ b/frontend/src/cell-details.js
@@ -1,5 +1,6 @@
 import { Fragment } from "react";
 
+import Tooltip from "./tooltip";
 import { useViewBox } from "./hooks";
 
 import "./cell-details.css";
@@ -63,18 +64,19 @@ const CellDetails = ({ selectedCell }) => {
             const y = top + (index + 1) * size;
             return (
               <Fragment key={index}>
-                <text
-                  x={left - size * 0.75}
-                  y={y}
-                  textAnchor="end"
-                  dominantBaseline="middle"
-                  fontSize={size}
-                  title={lemma.name}
-                >
-                  {lemma.name.length > maxChars
-                    ? lemma.name.substr(0, maxChars) + "..."
-                    : lemma.name}
-                </text>
+                <Tooltip content={lemma.name}>
+                  <text
+                    x={left - size * 0.75}
+                    y={y}
+                    textAnchor="end"
+                    dominantBaseline="middle"
+                    fontSize={size}
+                  >
+                    {lemma.name.length > maxChars
+                      ? lemma.name.substr(0, maxChars) + "..."
+                      : lemma.name}
+                  </text>
+                </Tooltip>
                 <rect
                   x={left}
                   y={y - size / 4}

--- a/frontend/src/cloud-buttons.js
+++ b/frontend/src/cloud-buttons.js
@@ -1,11 +1,9 @@
-import { createPortal } from "react-dom";
-
 import { startImage } from "./map-sections";
 import { endImage } from "./map-sections";
 import { range } from "./map-sections";
 import { getPcNum } from "./map-sections";
 import { getCloudUrl } from "./map-sections";
-import { useTooltip } from "./hooks";
+import Tooltip from "./tooltip";
 
 import "./cloud-buttons.css";
 
@@ -22,42 +20,34 @@ const CloudButtons = ({ selectedPc, setSelectedPc }) => (
 export default CloudButtons;
 
 // cloud image button component
-const CloudButton = ({ number, selectedPc, setSelectedPc }) => {
-  // tooltip
-  const { show, anchorRef, tooltipRef, tooltipProps, update } = useTooltip();
-
-  // render
-  return (
-    <>
-      <button
-        ref={anchorRef}
-        className="cloud_button"
-        data-number={getPcNum(number)}
-        data-selected={selectedPc === number}
-        onClick={() =>
-          selectedPc === number ? setSelectedPc(null) : setSelectedPc(number)
-        }
-      >
-        <img
-          src={getCloudUrl(number)}
-          title={"Select principal component " + getPcNum(number)}
-          alt={"Select principal component " + getPcNum(number)}
-          onLoad={update}
-        />
-      </button>
-      {show &&
-        createPortal(
-          <img
-            ref={tooltipRef}
-            src={getCloudUrl(number)}
-            className="cloud_enlarged"
-            title={"Select principal component " + getPcNum(number)}
-            alt={"Select principal component " + getPcNum(number)}
-            onLoad={update}
-            {...tooltipProps}
-          />,
-          document.body
-        )}
-    </>
-  );
-};
+const CloudButton = ({ number, selectedPc, setSelectedPc }) => (
+  <Tooltip
+    content={
+      <img
+        src={getCloudUrl(number)}
+        className="cloud_enlarged"
+        alt={"Principal component " + getPcNum(number)}
+        // put min estimated height to avoid flickering
+        style={{ minHeight: "300px" }}
+      />
+    }
+  >
+    <button
+      className="cloud_button"
+      data-number={getPcNum(number)}
+      data-selected={selectedPc === number}
+      title={
+        (selectedPc === number ? "Deselect" : "Select") +
+        " this principal component"
+      }
+      onClick={() =>
+        selectedPc === number ? setSelectedPc(null) : setSelectedPc(number)
+      }
+    >
+      <img
+        src={getCloudUrl(number)}
+        alt={"Principal component " + getPcNum(number)}
+      />
+    </button>
+  </Tooltip>
+);

--- a/frontend/src/hooks.js
+++ b/frontend/src/hooks.js
@@ -1,8 +1,6 @@
-import { useState } from 'react';
-import { useEffect } from 'react';
-import { useCallback } from 'react';
-import { useRef } from 'react';
-import { usePopper } from 'react-popper';
+import { useState } from "react";
+import { useEffect } from "react";
+import { useRef } from "react";
 
 // get fitted view box of svg
 export const useViewBox = (rerender) => {
@@ -11,72 +9,12 @@ export const useViewBox = (rerender) => {
 
   useEffect(() => {
     // if svg not mounted yet, exit
-    if (!svg.current)
-      return;
+    if (!svg.current) return;
     // get bbox of content in svg
     const { x, y, width, height } = svg.current.getBBox();
     // set view box to bbox, essentially fitting view to content
-    setViewBox([x, y, width, height].map((n) => n.toFixed(2)).join(' '));
+    setViewBox([x, y, width, height].map((n) => n.toFixed(2)).join(" "));
   }, [rerender]);
 
   return [svg, viewBox];
-};
-
-// use tooltip
-export const useTooltip = (delay = 200) => {
-  const [show, setShow] = useState(false);
-  const [anchor, anchorRef] = useState(null);
-  const [tooltip, tooltipRef] = useState(null);
-
-  // tooltip timer
-  const timeout = useRef();
-
-  // make tooltip
-  const { styles, attributes, update } = usePopper(anchor, tooltip, {
-    placement: 'top',
-    modifiers: [
-      // https://github.com/popperjs/popper-core/issues/1138
-      { name: 'computeStyles', options: { adaptive: false } },
-      { name: 'offset', options: { offset: [0, 10] } },
-      { name: 'flip', options: { rootBoundary: 'document' } }
-    ]
-  });
-
-  // props to attach to tooltip element
-  const tooltipProps = {
-    style: styles.popper,
-    ...attributes.popper
-  };
-
-  // open tooltip
-  const open = useCallback(() => {
-    window.clearTimeout(timeout.current);
-    timeout.current = window.setTimeout(() => setShow(true), delay);
-  }, [delay]);
-
-  // close tooltip
-  const close = useCallback(() => {
-    window.clearTimeout(timeout.current);
-    setShow(false);
-  }, []);
-
-  // attach event listeners
-  useEffect(() => {
-    if (!anchor)
-      return;
-
-    anchor.addEventListener('mouseenter', open);
-    anchor.addEventListener('focus', open);
-    anchor.addEventListener('mouseleave', close);
-    anchor.addEventListener('blur', close);
-
-    return () => {
-      anchor.removeEventListener('mouseenter', open);
-      anchor.removeEventListener('focus', open);
-      anchor.removeEventListener('mouseleave', close);
-      anchor.removeEventListener('blur', close);
-    };
-  }, [anchor, close, open]);
-
-  return { show, anchorRef, tooltipRef, tooltipProps, update };
 };

--- a/frontend/src/map-sections.js
+++ b/frontend/src/map-sections.js
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useEffect } from "react";
 
+import Tooltip from "./tooltip";
 import CloudButtons from "./cloud-buttons";
 import Map from "./map";
 import Legend from "./legend";
@@ -45,10 +46,12 @@ const MapSections = ({ coordinates }) => {
   return (
     <>
       <section id="map">
-        <h3>
-          <i className="fas fa-map"></i>
-          <span>Map of PubMed Central</span>
-        </h3>
+        <Tooltip content="A visualization of the PubMed landscape based on on textual content and model data">
+          <h3>
+            <i className="fas fa-map"></i>
+            <span>Map of PubMed Central</span>
+          </h3>
+        </Tooltip>
         <CloudButtons {...{ selectedPc, setSelectedPc }} />
         <Map
           {...{ cells, selectedPc, selectedCell, setSelectedCell, coordinates }}

--- a/frontend/src/preprint-info.js
+++ b/frontend/src/preprint-info.js
@@ -5,34 +5,39 @@ const link = "https://doi.org/";
 // preprint info section
 
 const PreprintInfo = ({
-  preprint: { id, title, authors, journal, year, prelim },
+  preprint: { id, title, authors, journal, year, prelim, text },
 }) => (
   <section id="your-preprint">
     <h3>
       <i className="fas fa-feather-alt"></i>
       <span>Your Preprint</span>
     </h3>
-    <p>
-      <a href={link + id} className="card_detail">
-        {title}
-      </a>
-      <span className="card_detail truncate" tabIndex="0">
-        {authors}
-      </span>
-      <span className="card_detail truncate" tabIndex="0">
-        {journal} · {year}
-      </span>
-    </p>
-    {prelim && (
-      <Tooltip
-        content="These results were generated using the PDF version of the
-                preprint, which is less reliable and can reduce the accuracy of
-                predictions. Check back later when the full-text version is
-                available."
-      >
+    {!text && (
+      <p>
+        <a href={link + id} className="card_detail">
+          {title}
+        </a>
+        <span className="card_detail truncate" tabIndex="0">
+          {authors}
+        </span>
+        <span className="card_detail truncate" tabIndex="0">
+          {journal} · {year}
+        </span>
+      </p>
+    )}
+    {!text && prelim && (
+      <Tooltip content="These results were generated using the PDF version of the preprint, which is less reliable and can reduce the accuracy of predictions. Check back later when the full-text version is available.">
         <p className="center gray">
           <i className="fas fa-info-circle"></i>
           <span>Preliminary results</span>
+        </p>
+      </Tooltip>
+    )}
+    {text && (
+      <Tooltip content="You uploaded a plain text version of your preprint">
+        <p className="center gray">
+          <i className="fas fa-info-circle"></i>
+          <span>Plain text</span>
         </p>
       </Tooltip>
     )}

--- a/frontend/src/preprint-info.js
+++ b/frontend/src/preprint-info.js
@@ -1,5 +1,4 @@
-import { createPortal } from "react-dom";
-import { useTooltip } from "./hooks";
+import Tooltip from "./tooltip";
 
 const link = "https://doi.org/";
 
@@ -7,52 +6,37 @@ const link = "https://doi.org/";
 
 const PreprintInfo = ({
   preprint: { id, title, authors, journal, year, prelim },
-}) => {
-  // tooltip
-  const { show, anchorRef, tooltipRef, tooltipProps } = useTooltip();
-
-  return (
-    <section id="your-preprint">
-      <h3>
-        <i className="fas fa-feather-alt"></i>
-        <span>Your Preprint</span>
-      </h3>
-      <p>
-        <a href={link + id} title={title} className="card_detail">
-          {title}
-        </a>
-        <span title={authors} className="card_detail truncate" tabIndex="0">
-          {authors}
-        </span>
-        <span
-          title={journal + " · " + year}
-          className="card_detail truncate"
-          tabIndex="0"
-        >
-          {journal} · {year}
-        </span>
-      </p>
-      {prelim && (
-        <>
-          <hr />
-          <p ref={anchorRef} className="center gray">
-            <i className="fas fa-info-circle"></i>
-            <span>Preliminary results</span>
-          </p>
-          {show &&
-            createPortal(
-              <span ref={tooltipRef} {...tooltipProps} className="tooltip">
-                These results were generated using the PDF version of the
+}) => (
+  <section id="your-preprint">
+    <h3>
+      <i className="fas fa-feather-alt"></i>
+      <span>Your Preprint</span>
+    </h3>
+    <p>
+      <a href={link + id} className="card_detail">
+        {title}
+      </a>
+      <span className="card_detail truncate" tabIndex="0">
+        {authors}
+      </span>
+      <span className="card_detail truncate" tabIndex="0">
+        {journal} · {year}
+      </span>
+    </p>
+    {prelim && (
+      <Tooltip
+        content="These results were generated using the PDF version of the
                 preprint, which is less reliable and can reduce the accuracy of
                 predictions. Check back later when the full-text version is
-                available.
-              </span>,
-              document.body
-            )}
-        </>
-      )}
-    </section>
-  );
-};
+                available."
+      >
+        <p className="center gray">
+          <i className="fas fa-info-circle"></i>
+          <span>Preliminary results</span>
+        </p>
+      </Tooltip>
+    )}
+  </section>
+);
 
 export default PreprintInfo;

--- a/frontend/src/search.css
+++ b/frontend/src/search.css
@@ -6,6 +6,9 @@
   height: 40px;
   margin: 20px auto;
 }
+.search[data-drag="true"] {
+  box-shadow: 0 0 0 20px var(--orange);
+}
 .search_input,
 .search_button {
   border: none;

--- a/frontend/src/search.js
+++ b/frontend/src/search.js
@@ -8,6 +8,8 @@ import { getNeighborsMetadata } from "./backend";
 import { cleanPreprint } from "./backend";
 import { cleanNeighbors } from "./backend";
 
+import Tooltip from "./tooltip";
+
 import { loading } from "./status";
 import { success } from "./status";
 
@@ -54,12 +56,8 @@ const Search = ({
 
       // get preprint info and neighbor data
       try {
-        let {
-          preprint,
-          similarJournals,
-          similarPapers,
-          coordinates,
-        } = await getNeighbors(doi);
+        let { preprint, similarJournals, similarPapers, coordinates } =
+          await getNeighbors(doi);
         preprint = cleanPreprint(preprint);
         similarJournals = await getNeighborsMetadata(similarJournals);
         similarPapers = await getNeighborsMetadata(similarPapers);
@@ -139,14 +137,15 @@ const Search = ({
           disabled={status === loading}
           onFocus={({ target }) => target.select()}
         />
-        <button
-          className="search_button"
-          type="submit"
-          title="Search for related papers and journals"
-          disabled={status === loading}
-        >
-          <i className="fas fa-search"></i>
-        </button>
+        <Tooltip content="Search for related papers and journals">
+          <button
+            className="search_button"
+            type="submit"
+            disabled={status === loading}
+          >
+            <i className="fas fa-search"></i>
+          </button>
+        </Tooltip>
       </form>
     </section>
   );

--- a/frontend/src/search.js
+++ b/frontend/src/search.js
@@ -27,26 +27,26 @@ const Search = ({
   setSimilarPapers,
   setCoordinates,
 }) => {
-  // default query
-  const [query, setQuery] = useState(getUrl() || defaultSearch);
+  const [doi, setDoi] = useState(getUrl() || defaultSearch); // doi query
+  const [drag, setDrag] = useState(false); // text upload drag
 
   // on type
   const onChange = useCallback(
-    (event) => setQuery(event.target.value.trim()),
+    (event) => setDoi(event.target.value.trim()),
     []
   );
 
   // search
   const search = useCallback(
-    async (doi, updateUrl = true) => {
-      // clean doi
-      doi = cleanDoi(doi);
-
-      // update search box with cleaned doi
-      setQuery(doi);
+    async ({ doi, text }, updateUrl = true) => {
+      // clean doi and update search box
+      if (doi) {
+        doi = cleanDoi(doi);
+        setDoi(doi);
+      }
 
       // exit if doi query empty
-      if (!doi) return;
+      if (doi === "") return;
 
       // update url based on search
       if (updateUrl) setUrl(doi);
@@ -57,7 +57,7 @@ const Search = ({
       // get preprint info and neighbor data
       try {
         let { preprint, similarJournals, similarPapers, coordinates } =
-          await getNeighbors(doi);
+          await getNeighbors({ doi, text });
         preprint = cleanPreprint(preprint);
         similarJournals = await getNeighborsMetadata(similarJournals);
         similarPapers = await getNeighborsMetadata(similarPapers);
@@ -69,6 +69,7 @@ const Search = ({
         setSimilarPapers(similarPapers);
         setCoordinates(coordinates);
       } catch (error) {
+        console.log(error);
         if (error.name !== "CustomError")
           error.message = "Couldn't get results";
         setStatus(error.message);
@@ -94,9 +95,9 @@ const Search = ({
     const doi = getUrl();
     if (!doi) return;
     // put doi in search box
-    setQuery(doi);
+    setDoi(doi);
     // run search, without updating url since browser does this automatically
-    search(doi, false);
+    search({ doi }, false);
   }, [search]);
 
   // search for doi in url if any on first load
@@ -110,6 +111,30 @@ const Search = ({
     return () => window.removeEventListener("popstate", onNav);
   }, [onNav, search]);
 
+  // on button drag file over, set drag flag on
+  const onDragEnter = () => setDrag(true);
+
+  // on button drag file off, set drag flag off
+  const onDragLeave = () => setDrag(false);
+
+  // on button drag file
+  const onDragOver = (event) => event.preventDefault();
+
+  // on button file drop
+  const onDrop = async (event) => {
+    // prevent navigating
+    event.preventDefault();
+    event.stopPropagation();
+    setDrag(false);
+
+    // get text file contents
+    const file = event.dataTransfer.files[0];
+    if (file.type !== "text/plain") return;
+    const text = (await file.text()) || "";
+
+    // run search
+    search({ text });
+  };
   // render
   return (
     <section id="search">
@@ -125,12 +150,17 @@ const Search = ({
           // prevent page from navigating away/refreshing on submit
           event.preventDefault();
           // run search
-          search(query);
+          search({ doi });
         }}
+        onDragEnter={onDragEnter}
+        onDragLeave={onDragLeave}
+        onDragOver={onDragOver}
+        onDrop={onDrop}
+        data-drag={drag}
       >
         <input
           className="search_input"
-          value={query}
+          value={doi}
           onChange={onChange}
           type="text"
           placeholder="e.g. 10.1101/833400"
@@ -154,8 +184,7 @@ const Search = ({
 // clean what user types into search box for convenience
 // remove everything before first number, eg "doi:"
 // remove version at end, eg "v4"
-const cleanDoi = (query) =>
-  query.replace(/^\D*/g, "").replace(/v\d+$/g, "").trim();
+const cleanDoi = (doi) => doi.replace(/^\D*/g, "").replace(/v\d+$/g, "").trim();
 
 // get doi from url
 const getUrl = () =>
@@ -165,7 +194,8 @@ const getUrl = () =>
 const setUrl = (doi) => {
   const oldUrl = window.location.href;
   const base = window.location.href.split(/[?#]/)[0];
-  const newUrl = base + "?doi=" + doi;
+  const newUrl = base + (doi ? "?doi=" + doi : "");
+  console.log(doi, newUrl);
   // compare old to new url to prevent duplicate history entries when refreshing
   if (oldUrl !== newUrl) window.history.pushState(null, null, newUrl);
 };

--- a/frontend/src/search.js
+++ b/frontend/src/search.js
@@ -195,7 +195,6 @@ const setUrl = (doi) => {
   const oldUrl = window.location.href;
   const base = window.location.href.split(/[?#]/)[0];
   const newUrl = base + (doi ? "?doi=" + doi : "");
-  console.log(doi, newUrl);
   // compare old to new url to prevent duplicate history entries when refreshing
   if (oldUrl !== newUrl) window.history.pushState(null, null, newUrl);
 };

--- a/frontend/src/similar-journals.js
+++ b/frontend/src/similar-journals.js
@@ -1,5 +1,7 @@
 import color from "color";
 
+import Tooltip from "./tooltip";
+
 import "./card.css";
 
 const rankColorA = color("#ff980020");
@@ -11,19 +13,22 @@ const link = "https://www.google.com/search?q=";
 
 const SimilarJournals = ({ similarJournals }) => (
   <section id="similar-journals">
-    <h3>
-      <i className="fas fa-bookmark"></i>
-      <span>Most Similar Journals</span>
-    </h3>
+    <Tooltip content="The closest journals within our generated paper embedding space">
+      <h3>
+        <i className="fas fa-bookmark"></i>
+        <span>Most Similar Journals</span>
+      </h3>
+    </Tooltip>
     {similarJournals.map(({ journal, rank, distance, strength }, index) => (
       <div key={index} className="card">
-        <div
-          className="card_score"
-          title={"Distance score: " + distance}
-          style={{ backgroundColor: rankColorB.mix(rankColorA, strength) }}
-        >
-          {rank}
-        </div>
+        <Tooltip content={"Distance score: " + distance.toFixed(2)}>
+          <div
+            className="card_score"
+            style={{ backgroundColor: rankColorB.mix(rankColorA, strength) }}
+          >
+            {rank}
+          </div>
+        </Tooltip>
         <div className="card_details">
           <a href={link + journal} className="card_detail">
             {journal}

--- a/frontend/src/similar-papers.js
+++ b/frontend/src/similar-papers.js
@@ -1,5 +1,7 @@
 import color from "color";
 
+import Tooltip from "./tooltip";
+
 import "./card.css";
 
 const rankColorA = color("#ff980020");
@@ -11,35 +13,34 @@ const link = "https://www.ncbi.nlm.nih.gov/pmc/articles/";
 
 const SimilarPapers = ({ similarPapers }) => (
   <section id="similar-papers">
-    <h3>
-      <i className="fas fa-scroll"></i>
-      <span>Most Similar Papers</span>
-    </h3>
+    <Tooltip content="The closest paper within our generated paper embedding space">
+      <h3>
+        <i className="fas fa-scroll"></i>
+        <span>Most Similar Papers</span>
+      </h3>
+    </Tooltip>
     {similarPapers.map(
       (
         { id, title, authors, year, journal, rank, distance, strength },
         index
       ) => (
         <div key={index} className="card">
-          <div
-            className="card_score"
-            title={"Distance score: " + distance}
-            style={{ backgroundColor: rankColorB.mix(rankColorA, strength) }}
-          >
-            {rank}
-          </div>
+          <Tooltip content={"Distance score: " + distance.toFixed(2)}>
+            <div
+              className="card_score"
+              style={{ backgroundColor: rankColorB.mix(rankColorA, strength) }}
+            >
+              {rank}
+            </div>
+          </Tooltip>
           <div className="card_details">
-            <a href={link + id} title={title} className="card_detail">
+            <a href={link + id} className="card_detail">
               {title}
             </a>
-            <div title={authors} className="card_detail truncate" tabIndex="0">
+            <div className="card_detail truncate" tabIndex="0">
               {authors}
             </div>
-            <div
-              title={journal + " · " + year}
-              className="card_detail truncate"
-              tabIndex="0"
-            >
+            <div className="card_detail truncate" tabIndex="0">
               {journal} · {year}
             </div>
           </div>

--- a/frontend/src/tooltip.css
+++ b/frontend/src/tooltip.css
@@ -1,0 +1,47 @@
+.tooltip {
+  --arrow: 10px;
+
+  position: absolute;
+  left: -9999px;
+  top: -9999px;
+  max-width: min(90vw, 500px);
+  padding: 5px;
+  background: var(--black);
+  font-size: 0.9rem;
+  text-align: center;
+  z-index: 10;
+  pointer-events: none;
+}
+.tooltip > * {
+  color: var(--white);
+}
+.tooltip_content {
+  padding: 10px;
+}
+.tooltip_arrow {
+  position: absolute;
+  width: var(--arrow);
+  height: var(--arrow);
+  z-index: -1;
+}
+.tooltip_arrow:after {
+  content: "";
+  position: absolute;
+  left: 0;
+  width: var(--arrow);
+  height: var(--arrow);
+  background: var(--black);
+  transform: rotate(45deg);
+}
+.tooltip[data-popper-placement="top"] .tooltip_arrow {
+  bottom: calc(-0.5 * var(--arrow));
+}
+.tooltip[data-popper-placement="bottom"] .tooltip_arrow {
+  top: calc(-0.5 * var(--arrow));
+}
+.tooltip[data-popper-placement="left"] .tooltip_arrow {
+  right: calc(-0.5 * var(--arrow));
+}
+.tooltip[data-popper-placement="right"] .tooltip_arrow {
+  left: calc(-0.5 * var(--arrow));
+}

--- a/frontend/src/tooltip.js
+++ b/frontend/src/tooltip.js
@@ -1,0 +1,113 @@
+import { useState } from "react";
+import { useEffect } from "react";
+import { useRef } from "react";
+import { isValidElement } from "react";
+import { cloneElement } from "react";
+import { forwardRef } from "react";
+import { Children } from "react";
+import { createPortal } from "react-dom";
+import { usePopper } from "react-popper";
+
+import "./tooltip.css";
+
+const placement = "top";
+const delay = 100;
+
+const Tooltip = forwardRef(({ content, children, ...rest }, ref) => {
+  // popper elements
+  const [target, setTarget] = useState(null);
+  const [popper, setPopper] = useState(null);
+  const [arrow, setArrow] = useState(null);
+
+  // open state
+  const [isOpen, setOpen] = useState(false);
+
+  // open delay timer
+  const timer = useRef();
+
+  // open tooltip
+  const open = () => {
+    // don't open if no content
+    if (!content) return;
+    window.clearTimeout(timer?.current);
+    timer.current = window.setTimeout(() => setOpen(true), delay);
+  };
+
+  // close tooltip
+  const close = () => {
+    window.clearTimeout(timer?.current);
+    setOpen(false);
+  };
+
+  // popper.js options
+  let options = {
+    placement,
+    modifiers: [
+      // https://github.com/popperjs/popper-core/issues/1138
+      { name: "computeStyles", options: { adaptive: false } },
+      { name: "offset", options: { offset: [0, 10] } },
+      { name: "arrow", options: { element: arrow, padding: 10 } },
+    ],
+  };
+  const { styles, attributes, update } = usePopper(target, popper, options);
+
+  useEffect(() => {
+    if (update) update();
+  }, [content, update]);
+
+  // attach props to child
+  if (children) {
+    const props = {
+      ...rest,
+      onMouseEnter: open,
+      onMouseLeave: close,
+      onFocus: open,
+      onBlur: close,
+      ref: (el) => {
+        setTarget(el);
+        return ref;
+      },
+    };
+    children = Children.map(children, (element, index) => {
+      if (index > 0) return element;
+      if (isValidElement(element)) return cloneElement(element, props);
+      return element;
+    });
+  }
+
+  // attach props to content
+  if (isValidElement(content)) {
+    const props = {
+      onLoad: update,
+    };
+    content = cloneElement(content, props);
+  }
+
+  return (
+    <>
+      {children}
+      {isOpen &&
+        createPortal(
+          <div
+            ref={setPopper}
+            className="tooltip"
+            style={{ ...styles.popper }}
+            {...attributes.popper}
+          >
+            {typeof content === "string" && (
+              <div className="tooltip_content">{content}</div>
+            )}
+            {typeof content !== "string" && content}
+            <div
+              ref={setArrow}
+              className="tooltip_arrow"
+              style={styles.arrow}
+            />
+          </div>,
+          document.body
+        )}
+    </>
+  );
+});
+
+export default Tooltip;


### PR DESCRIPTION
- refine readme and defer mostly to manuscript to avoid repeating info
- make new tooltip component with arrow/caret, instead of tooltip hook
- put tooltips on headings
- implement plain text upload by dragging text file onto search box
- replace `title` attributes on various things with tooltip component
- other minor fixes and tweaks