### PR TITLE
code to enable arxiv

### DIFF
--- a/server/document_downloader.py
+++ b/server/document_downloader.py
@@ -62,7 +62,7 @@ def get_doi_content(user_doi):
             f"{doc_url}/early/{accepted_date}/{user_doi.split('/')[-1]}.source.xml"
         )
 
-    # If not arxiv definitely bioRxiv/medRxiv
+    # If not bioRxiv/medRxiv definitely arxiv
     else:
         doc_url = f"https://export.arxiv.org/api/query?id_list={user_doi}"
         response = requests.get(doc_url)

--- a/server/document_downloader.py
+++ b/server/document_downloader.py
@@ -1,64 +1,127 @@
+import datetime
+import lxml.etree as ET
+import re
+import requests
+
 import cachetools.func
 from settings import CACHE_TTL_SECS, CACHE_MAX_SIZE
-import requests
 from flask_restful import abort
 from utils import server_log
+
 
 @cachetools.func.ttl_cache(ttl=CACHE_TTL_SECS, maxsize=CACHE_MAX_SIZE)
 def get_doi_content(user_doi):
     """
     This function is designed to render the paper-journal
-    network for the user given a biorxiv doi
+    network for the user given identifier.
+
+    Code Grabs the latest preprint version to generate results.
+
     Args:
-        user_doi - a biorxiv doi that grabs the most current version of a preprint
+        user_doi - user provided biorxiv/medrxiv doi or arxiv id
     """
 
-    # Try pinging biorxiv server first
-    content = ping_biorxiv_or_medrxiv(user_doi, server="biorxiv")
-    doc_url = f"http://biorxiv.org/content"
+    # create flag if xml is found
+    xml_found = False
 
-    # If no match found try medrxiv
-    if content is None:
-        content = ping_biorxiv_or_medrxiv(user_doi, server="medrxiv")
-        doc_url = f"http://medrxiv.org/content"
+    # Check to see if user_doi is a biorxiv/medrxiv doi
+    # if not then resort to searching for arxiv
+    bio_med_rxiv = re.search(r"10\.1101\/", user_doi) is not None
 
-        # If no match at all then raise the red flag
+    if bio_med_rxiv:
+        # Try pinging biorxiv server first
+        content = ping_biorxiv_or_medrxiv(user_doi, server="biorxiv")
+        doc_url = f"http://biorxiv.org/content"
+
+        # If no match found try medrxiv
         if content is None:
-            message = f"Cannot find document {user_doi} in either biorxiv or medrxiv."
+            content = ping_biorxiv_or_medrxiv(user_doi, server="medrxiv")
+            doc_url = f"http://medrxiv.org/content"
+
+            # If no match at all then raise the red flag
+            if content is None:
+                message = (
+                    f"Cannot find document {user_doi} in either biorxiv or medrxiv."
+                )
+                server_log(f"{message}\n")
+                abort(404, message=message)
+
+        latest_paper = content["collection"][-1]
+
+        paper_metadata = {
+            "title": latest_paper["title"],
+            "authors": latest_paper["authors"],
+            "doi": latest_paper["doi"],
+            "accepted_date": latest_paper["date"],
+            "publisher": "Cold Spring Harbor Laboratory",
+        }
+
+        # Grab latest version of the XML file if available
+        accepted_date = latest_paper["date"].replace("-", "/")
+        file_url = (
+            f"{doc_url}/early/{accepted_date}/{user_doi.split('/')[-1]}.source.xml"
+        )
+
+    # If not arxiv definitely bioRxiv/medRxiv
+    else:
+        doc_url = f"https://export.arxiv.org/api/query?id_list={user_doi}"
+        response = requests.get(doc_url)
+
+        # If document cannot be found in arxiv log and report
+        if response is None:
+            message = f"Cannot reach arxiv api server."
             server_log(f"{message}\n")
             abort(404, message=message)
 
-    latest_paper = content["collection"][-1]
+        latest_paper, latest_file_url = parse_arxiv_output(response.text)
 
-    paper_metadata = {
-        "title": latest_paper["title"],
-        "authors": latest_paper["authors"],
-        "doi": latest_paper["doi"],
-        "accepted_date": latest_paper["date"],
-        "publisher": "Cold Spring Harbor Laboratory",
-    }
+        if latest_paper == None:
+            message = f"Cannot find {user_doi} on arxiv's api server."
+            server_log(f"{message}\n")
+            abort(404, message=message)
 
-    # Grab latest version of the XML file if available
-    accepted_date = latest_paper["date"].replace("-", "/")
-    file_url = f"{doc_url}/early/{accepted_date}/{user_doi.split('/')[-1]}.source.xml"
-    xml_found = False
+        # I doubt this will execute but
+        # there could be a case where a document's download link cannot be found
+        if latest_file_url == None:
+            message = f"Cannot find download link for {user_doi} on arxiv's api server."
+            server_log(f"{message}\n")
+            abort(404, message=message)
 
-    try:
-        response = requests.get(file_url)
-        if response.status_code == 200:
-            xml_found = True
+        paper_metadata = {
+            "title": latest_paper["title"],
+            "authors": latest_paper["authors"],
+            "doi": user_doi,
+            "accepted_date": latest_paper["date"],
+            "publisher": "Arxiv - Cornell Univeristy",
+        }
 
-    except Exception as e:
-        message = f"Cannot connect to {file_url}"
-        server_log(f"{message}: {e}\n")
+    # biorxiv has xml files available
+    # This block here is designed to first attempt to retrieve the xml file
+    # then defaults to pdf if xml cannot be found
+    # Arxiv only has pdf so can skip this section
+    if bio_med_rxiv:
+        try:
+            response = requests.get(file_url)
+            if response.status_code == 200:
+                xml_found = True
+
+        except Exception as e:
+            message = f"Cannot connect to {file_url}"
+            server_log(f"{message}: {e}\n")
 
     # If xml not found then use PDF version
     if not xml_found:
 
         # Grab latest version of PDF file
-        file_url = f"{doc_url}/{user_doi}v{latest_paper['version']}.full.pdf"
+        file_url = (
+            f"{doc_url}/{user_doi}v{latest_paper['version']}.full.pdf"
+            if bio_med_rxiv
+            else f"https://export.arxiv.org/pdf/{latest_file_url}"
+        )
+
         try:
             response = requests.get(file_url)
+
         except Exception as e:
             message = f"Cannot connect to {file_url}"
             server_log(f"{message}: {e}\n")
@@ -70,6 +133,55 @@ def get_doi_content(user_doi):
         abort(response.status_code, message=message)
 
     return response.content, paper_metadata, xml_found
+
+
+def parse_arxiv_output(xml_feed):
+    """
+    This function is designed to parse output from the arxiv server
+
+    Args:
+        xml_feed - the xml output obtained from export.arxiv.org api server
+    """
+
+    arxiv_api_xml_obj = ET.fromstring(str.encode(xml_feed))
+
+    # Extract the metadata
+    title = arxiv_api_xml_obj.xpath(
+        '/*[local-name()="feed"]/*[local-name()="entry"]'
+        '/*[local-name()="title"]/text()'
+    )[0]
+
+    # Arxiv server reports back an error if document cannnot be found
+    # this circumvents the rest of the code if the document cannot be found
+    if title == "Error":
+        return None, None
+
+    # Remove pesky newlines for title if present
+    title = title.replace("\n", "")
+
+    authors = arxiv_api_xml_obj.xpath(
+        '/*[local-name()="feed"]/*[local-name()="entry"]'
+        '/*[local-name()="author"]/*[local-name()="name"]/text()'
+    )
+    authors = ";".join(authors)
+
+    accepted_date = arxiv_api_xml_obj.xpath(
+        '/*[local-name()="feed"]/*[local-name()="entry"]'
+        '/*[local-name()="published"]/text()'
+    )[0]
+
+    accepted_date = datetime.datetime.strptime(
+        accepted_date, "%Y-%m-%dT%H:%M:%SZ"
+    ).strftime("%Y-%m-%d")
+
+    file_url = arxiv_api_xml_obj.xpath(
+        '/*[local-name()="feed"]/*[local-name()="entry"]'
+        '/*[local-name()="link"][@type="application/pdf"]'
+    )[0]
+
+    latest_file_version = file_url.attrib["href"].split("/")[-1]
+
+    return dict(title=title, date=accepted_date, authors=authors), latest_file_version
 
 
 def ping_biorxiv_or_medrxiv(doi, server="biorxiv"):


### PR DESCRIPTION
Closes #118 

As mentioned in the issue above. Got a request to enable parsing of arxiv preprints for the website. The code below enables that feature.

I don't know who the new backend developer is for the lab. Please feel free to tag them in this PR or notify them to review this update. Lastly, whoever has access to the sentry logs for our server please let me know. I'd like to take a look at the messages the server is giving back in regards to this persisting xml file issue.